### PR TITLE
Specify Firebase auth dependency version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,5 +71,5 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-test-manifest")
     implementation(platform("com.google.firebase:firebase-bom:34.3.0"))
     implementation("com.google.firebase:firebase-analytics")
-    implementation("com.google.firebase:firebase-auth-ktx")
+    implementation("com.google.firebase:firebase-auth-ktx:23.0.0")
 }


### PR DESCRIPTION
## Summary
- define an explicit version for the Firebase Auth KTX dependency to ensure it is resolvable via Gradle

## Testing
- ./gradlew :app:dependencies --configuration debugRuntimeClasspath *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ddd4f19af8832391f1a4b0145bdbec