### PR TITLE
Add image message support with previews

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("io.coil-kt:coil-compose:2.6.0")
     implementation("androidx.compose.material3:material3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation(platform("androidx.compose:compose-bom:2024.09.01"))
@@ -79,4 +80,5 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:33.1.2"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-storage-ktx")
 }

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/ChatScreen.kt
@@ -1,17 +1,26 @@
 package com.example.lingaguchat.ui.chat
 
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
 import com.google.firebase.firestore.FirebaseFirestore
 import java.text.DateFormat
 import java.util.*
@@ -26,6 +35,19 @@ fun ChatScreen(
 ) {
     val messages by chatViewModel.messages.collectAsState()
     var text by remember { mutableStateOf("") }
+
+    val context = LocalContext.current
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        uri?.let {
+            chatViewModel.sendImageMessage(currentUserEmail, selectedUserEmail, it) { success ->
+                if (!success) {
+                    Toast.makeText(context, "No se pudo enviar la imagen", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
 
     // nombres para UI
     var contactName by remember { mutableStateOf(selectedUserEmail.substringBefore("@")) }
@@ -56,7 +78,9 @@ fun ChatScreen(
         )
 
         LazyColumn(
-            modifier = Modifier.weight(1f).padding(8.dp)
+            modifier = Modifier
+                .weight(1f)
+                .padding(8.dp)
         ) {
             items(items = messages, key = { it.id }) { msg ->
                 val isMe = msg.sender == currentUserEmail
@@ -65,7 +89,9 @@ fun ChatScreen(
                     .format(Date(msg.timestamp))
 
                 Column(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
                     horizontalAlignment = if (isMe) Alignment.End else Alignment.Start
                 ) {
                     Text(
@@ -81,11 +107,40 @@ fun ChatScreen(
                         else
                             MaterialTheme.colorScheme.surfaceVariant
                     ) {
-                        Text(
-                            text = msg.text,
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
-                        )
+                        when (msg.type) {
+                            MessageType.IMAGE -> {
+                                Column(
+                                    modifier = Modifier.padding(8.dp),
+                                    horizontalAlignment = Alignment.CenterHorizontally
+                                ) {
+                                    msg.imageUrl?.let { imageUrl ->
+                                        AsyncImage(
+                                            model = imageUrl,
+                                            contentDescription = "Imagen enviada",
+                                            modifier = Modifier
+                                                .clip(RoundedCornerShape(12.dp))
+                                                .sizeIn(maxWidth = 220.dp, maxHeight = 220.dp),
+                                            contentScale = ContentScale.Crop
+                                        )
+                                    }
+                                    if (msg.text.isNotBlank()) {
+                                        Spacer(modifier = Modifier.height(6.dp))
+                                        Text(
+                                            text = msg.text,
+                                            style = MaterialTheme.typography.bodyLarge
+                                        )
+                                    }
+                                }
+                            }
+
+                            MessageType.TEXT -> {
+                                Text(
+                                    text = msg.text,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+                                )
+                            }
+                        }
                     }
                     Text(
                         text = timeText,
@@ -95,11 +150,16 @@ fun ChatScreen(
             }
         }
 
-        Row(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+        Row(modifier = Modifier.fillMaxWidth().padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { imagePickerLauncher.launch("image/*") }) {
+                Icon(Icons.Default.Image, contentDescription = "Enviar imagen")
+            }
             BasicTextField(
                 value = text,
                 onValueChange = { text = it },
-                modifier = Modifier.weight(1f).padding(8.dp)
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(8.dp)
             )
             Button(onClick = {
                 if (text.isNotBlank()) {

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/ChatViewModel.kt
@@ -1,14 +1,18 @@
 // ChatViewModel.kt
 package com.example.lingaguchat.ui.chat
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.util.UUID
 
 class ChatViewModel : ViewModel() {
     private val db = FirebaseFirestore.getInstance()
+    private val storage = FirebaseStorage.getInstance()
 
     private val _messages = MutableStateFlow<List<Message>>(emptyList())
     val messages: StateFlow<List<Message>> = _messages
@@ -61,9 +65,50 @@ class ChatViewModel : ViewModel() {
             sender = sender,
             receiver = receiver,
             text = text,
+            type = MessageType.TEXT,
             timestamp = System.currentTimeMillis()
         )
         docRef.set(newMessage)
+    }
+
+    fun sendImageMessage(
+        sender: String,
+        receiver: String,
+        imageUri: Uri,
+        onResult: (Boolean) -> Unit = {}
+    ) {
+        val imageRef = storage.reference
+            .child("chat_images/${UUID.randomUUID()}_${imageUri.lastPathSegment ?: "image"}")
+
+        imageRef.putFile(imageUri)
+            .continueWithTask { task ->
+                if (!task.isSuccessful) {
+                    task.exception?.let { throw it }
+                }
+                imageRef.downloadUrl
+            }
+            .addOnSuccessListener { downloadUri ->
+                val docRef = db.collection("messages").document()
+                val imageMessage = Message(
+                    id = docRef.id,
+                    sender = sender,
+                    receiver = receiver,
+                    text = "",
+                    imageUrl = downloadUri.toString(),
+                    type = MessageType.IMAGE,
+                    timestamp = System.currentTimeMillis()
+                )
+                docRef.set(imageMessage)
+                    .addOnSuccessListener { onResult(true) }
+                    .addOnFailureListener {
+                        println("🔥 image message send error: ${it.message}")
+                        onResult(false)
+                    }
+            }
+            .addOnFailureListener {
+                println("🔥 image upload error: ${it.message}")
+                onResult(false)
+            }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/Message.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/Message.kt
@@ -1,9 +1,13 @@
 package com.example.lingaguchat.ui.chat
 
+enum class MessageType { TEXT, IMAGE }
+
 data class Message(
     val id: String = "",
     val sender: String = "",
     val receiver: String = "",
     val text: String = "",
+    val imageUrl: String? = null,
+    val type: MessageType = MessageType.TEXT,
     val timestamp: Long = System.currentTimeMillis()
 )


### PR DESCRIPTION
## Summary
- add support for uploading chat images to Firebase Storage and saving them as a new message type
- update the chat UI to show image preview bubbles and expose an image picker action
- include Coil and Firebase Storage dependencies to render downloaded images

## Testing
- ./gradlew lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df2391783883238a50cebf7808c0bd