### PR TITLE
Add group chats, presence tracking, and encrypted messaging

### DIFF
--- a/app/src/main/java/com/example/lingaguchat/MainActivity.kt
+++ b/app/src/main/java/com/example/lingaguchat/MainActivity.kt
@@ -4,18 +4,20 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.lingaguchat.ui.auth.AuthScreen
 import com.example.lingaguchat.ui.auth.AuthViewModel
+import com.example.lingaguchat.ui.chat.ChatDestination
 import com.example.lingaguchat.ui.chat.ChatScreen
 import com.example.lingaguchat.ui.chat.DrawerContent
+import com.example.lingaguchat.ui.chat.PresenceManager
 import com.example.lingaguchat.ui.theme.LingaguChatTheme
 import kotlinx.coroutines.launch
-import androidx.compose.foundation.layout.padding
-import androidx.compose.ui.unit.dp
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,11 +32,24 @@ class MainActivity : ComponentActivity() {
                     val uiState by authViewModel.uiState
 
                     if (uiState.isAuthenticated) {
+                        val currentEmail = uiState.userEmail.orEmpty()
+                        LaunchedEffect(currentEmail) {
+                            if (currentEmail.isNotBlank()) {
+                                PresenceManager.setOnline(currentEmail)
+                            }
+                        }
+                        DisposableEffect(currentEmail) {
+                            onDispose {
+                                if (currentEmail.isNotBlank()) {
+                                    PresenceManager.setOffline(currentEmail)
+                                }
+                            }
+                        }
+
                         val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
                         val scope = rememberCoroutineScope()
 
-                        // 👇 estado para guardar el usuario seleccionado del drawer
-                        var selectedUser by remember { mutableStateOf<String?>(null) }
+                        var selectedChat by remember { mutableStateOf<ChatDestination?>(null) }
 
                         ModalNavigationDrawer(
                             drawerState = drawerState,
@@ -44,31 +59,33 @@ class MainActivity : ComponentActivity() {
                                     drawerContentColor = MaterialTheme.colorScheme.onSurface
                                 ) {
                                     DrawerContent(
-                                        currentUserEmail = uiState.userEmail.orEmpty(),
-                                        selectedUser = selectedUser,
-                                        onAccountSelected = { email ->
-                                            selectedUser = email
+                                        currentUserEmail = currentEmail,
+                                        selectedChat = selectedChat,
+                                        onChatSelected = { chat ->
+                                            selectedChat = chat
                                             scope.launch { drawerState.close() }
                                         },
-                                        onSignOut = { authViewModel.signOut() }
+                                        onSignOut = {
+                                            PresenceManager.setOffline(currentEmail)
+                                            authViewModel.signOut()
+                                        }
                                     )
                                 }
                             }
                         ) {
-                            if (selectedUser != null) {
+                            if (selectedChat != null) {
                                 ChatScreen(
-                                    currentUserEmail = uiState.userEmail.orEmpty(),
-                                    selectedUserEmail = selectedUser!!,
+                                    currentUserEmail = currentEmail,
+                                    destination = selectedChat!!,
                                     onOpenDrawer = { scope.launch { drawerState.open() } }
                                 )
                             } else {
-                                // Pantalla vacía si no has seleccionado contacto
                                 Surface(
                                     modifier = Modifier.fillMaxSize(),
                                     color = MaterialTheme.colorScheme.background
                                 ) {
                                     Text(
-                                        text = "Selecciona un contacto en el menú",
+                                        text = "Selecciona un chat en el menú",
                                         style = MaterialTheme.typography.bodyLarge,
                                         modifier = Modifier.padding(24.dp)
                                     )

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/ChatDestination.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/ChatDestination.kt
@@ -1,0 +1,10 @@
+package com.example.lingaguchat.ui.chat
+
+sealed class ChatDestination {
+    data class Private(val email: String) : ChatDestination()
+    data class Group(
+        val id: String,
+        val name: String,
+        val members: List<String>
+    ) : ChatDestination()
+}

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/ChatScreen.kt
@@ -26,14 +26,16 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ListenerRegistration
 import java.text.DateFormat
+import java.text.SimpleDateFormat
 import java.util.*
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatScreen(
     currentUserEmail: String,
-    selectedUserEmail: String,
+    destination: ChatDestination,
     chatViewModel: ChatViewModel = viewModel(),
     onOpenDrawer: () -> Unit
 ) {
@@ -56,27 +58,103 @@ fun ChatScreen(
         selectedImageUri = uri
     }
 
-    // nombres para UI
-    var contactName by remember { mutableStateOf(selectedUserEmail.substringBefore("@")) }
-    var meName by remember { mutableStateOf(currentUserEmail.substringBefore("@")) }
+    val db = remember { FirebaseFirestore.getInstance() }
 
-    // Cargar nombres y activar listeners del chat
-    LaunchedEffect(selectedUserEmail) {
-        val db = FirebaseFirestore.getInstance()
-        db.collection("users").document(selectedUserEmail).get()
-            .addOnSuccessListener { doc ->
-                contactName = doc.getString("name") ?: selectedUserEmail.substringBefore("@")
+    var title by remember { mutableStateOf("") }
+    var subtitle by remember { mutableStateOf<String?>(null) }
+    var memberNames by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+    var groupMembers by remember { mutableStateOf<List<String>>(if (destination is ChatDestination.Group) destination.members else emptyList()) }
+
+    DisposableEffect(destination) {
+        val usersCollection = db.collection("users")
+        var meReg: ListenerRegistration? = null
+        var contactReg: ListenerRegistration? = null
+        val groupRegs = mutableListOf<ListenerRegistration>()
+        var groupInfoReg: ListenerRegistration? = null
+
+        memberNames = emptyMap()
+        subtitle = null
+
+        when (destination) {
+            is ChatDestination.Private -> {
+                title = destination.email.substringBefore("@")
+                chatViewModel.listenPrivateMessages(currentUserEmail, destination.email)
+
+                meReg = usersCollection.document(currentUserEmail)
+                    .addSnapshotListener { snapshot, _ ->
+                        val meName = snapshot?.getString("name") ?: currentUserEmail.substringBefore("@")
+                        memberNames = memberNames.toMutableMap().apply { put(currentUserEmail, meName) }
+                    }
+
+                contactReg = usersCollection.document(destination.email)
+                    .addSnapshotListener { snapshot, _ ->
+                        val name = snapshot?.getString("name") ?: destination.email.substringBefore("@")
+                        memberNames = memberNames.toMutableMap().apply { put(destination.email, name) }
+                        val isOnline = snapshot?.getBoolean("online") ?: false
+                        val lastSeen = snapshot?.getLong("lastSeen")
+                        subtitle = if (isOnline) {
+                            "En línea"
+                        } else {
+                            lastSeen?.let { formatLastSeen(it) } ?: "Desconectado"
+                        }
+                        title = name
+                    }
             }
-        db.collection("users").document(currentUserEmail).get()
-            .addOnSuccessListener { doc ->
-                meName = doc.getString("name") ?: currentUserEmail.substringBefore("@")
+
+            is ChatDestination.Group -> {
+                title = destination.name
+                groupMembers = destination.members
+                chatViewModel.listenGroupMessages(destination.id)
+
+                groupInfoReg = db.collection("groups")
+                    .document(destination.id)
+                    .addSnapshotListener { snapshot, _ ->
+                        if (snapshot != null && snapshot.exists()) {
+                            title = snapshot.getString("name") ?: destination.name
+                            val members = snapshot.get("members") as? List<String>
+                            if (!members.isNullOrEmpty()) {
+                                groupMembers = members
+                            }
+                        }
+                    }
+
+                val allMembers = (destination.members + currentUserEmail).distinct()
+                allMembers.forEach { email ->
+                    val reg = usersCollection.document(email)
+                        .addSnapshotListener { snapshot, _ ->
+                            val name = snapshot?.getString("name") ?: email.substringBefore("@")
+                            memberNames = memberNames.toMutableMap().apply { put(email, name) }
+                        }
+                    groupRegs += reg
+                }
             }
-        chatViewModel.listenPrivateMessages(currentUserEmail, selectedUserEmail)
+        }
+
+        onDispose {
+            meReg?.remove()
+            contactReg?.remove()
+            groupRegs.forEach { it.remove() }
+            groupInfoReg?.remove()
+        }
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
-            title = { Text("Chat con $contactName") },
+            title = {
+                Column {
+                    Text(title)
+                    subtitle?.let { Text(it, style = MaterialTheme.typography.labelSmall) }
+                    if (destination is ChatDestination.Group && groupMembers.isNotEmpty()) {
+                        val membersText = groupMembers
+                            .map { memberNames[it] ?: it.substringBefore("@") }
+                            .joinToString(", ")
+                        Text(
+                            text = "Miembros: $membersText",
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+                }
+            },
             navigationIcon = {
                 IconButton(onClick = { onOpenDrawer() }) {
                     Icon(Icons.Default.Menu, contentDescription = "Menú")
@@ -92,7 +170,7 @@ fun ChatScreen(
         ) {
             items(items = messages, key = { it.id }) { msg ->
                 val isMe = msg.sender == currentUserEmail
-                val who = if (isMe) meName else contactName
+                val who = memberNames[msg.sender] ?: msg.sender.substringBefore("@")
                 val timeText = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault())
                     .format(Date(msg.timestamp))
 
@@ -188,32 +266,65 @@ fun ChatScreen(
                     when {
                         imageUri != null -> {
                             isSendingImage = true
-                            chatViewModel.sendImageMessage(
-                                sender = currentUserEmail,
-                                receiver = selectedUserEmail,
-                                imageUri = imageUri,
-                                caption = trimmedText
-                            ) { success ->
-                                isSendingImage = false
-                                if (success) {
-                                    text = ""
-                                    selectedImageUri = null
-                                } else {
-                                    Toast.makeText(
-                                        context,
-                                        "No se pudo enviar la imagen",
-                                        Toast.LENGTH_SHORT
-                                    ).show()
+                            when (destination) {
+                                is ChatDestination.Private -> {
+                                    chatViewModel.sendDirectImageMessage(
+                                        sender = currentUserEmail,
+                                        receiver = destination.email,
+                                        imageUri = imageUri,
+                                        caption = trimmedText
+                                    ) { success ->
+                                        isSendingImage = false
+                                        if (success) {
+                                            text = ""
+                                            selectedImageUri = null
+                                        } else {
+                                            Toast.makeText(
+                                                context,
+                                                "No se pudo enviar la imagen",
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                        }
+                                    }
+                                }
+                                is ChatDestination.Group -> {
+                                    chatViewModel.sendGroupImageMessage(
+                                        sender = currentUserEmail,
+                                        groupId = destination.id,
+                                        participants = groupMembers,
+                                        imageUri = imageUri,
+                                        caption = trimmedText
+                                    ) { success ->
+                                        isSendingImage = false
+                                        if (success) {
+                                            text = ""
+                                            selectedImageUri = null
+                                        } else {
+                                            Toast.makeText(
+                                                context,
+                                                "No se pudo enviar la imagen",
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                        }
+                                    }
                                 }
                             }
                         }
 
                         trimmedText.isNotBlank() -> {
-                            chatViewModel.sendMessage(
-                                currentUserEmail,
-                                selectedUserEmail,
-                                trimmedText
-                            )
+                            when (destination) {
+                                is ChatDestination.Private -> chatViewModel.sendDirectMessage(
+                                    currentUserEmail,
+                                    destination.email,
+                                    trimmedText
+                                )
+                                is ChatDestination.Group -> chatViewModel.sendGroupMessage(
+                                    sender = currentUserEmail,
+                                    groupId = destination.id,
+                                    participants = groupMembers,
+                                    text = trimmedText
+                                )
+                            }
                             text = ""
                         }
                     }
@@ -232,6 +343,23 @@ fun ChatScreen(
             }
         }
     }
+}
+
+private fun formatLastSeen(lastSeen: Long): String {
+    val calendar = Calendar.getInstance().apply { timeInMillis = lastSeen }
+    val formatter: DateFormat = if (isSameDay(calendar.timeInMillis, System.currentTimeMillis())) {
+        DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault())
+    } else {
+        SimpleDateFormat("dd MMM yyyy HH:mm", Locale.getDefault())
+    }
+    return "Últ. vez ${formatter.format(Date(lastSeen))}"
+}
+
+private fun isSameDay(time1: Long, time2: Long): Boolean {
+    val cal1 = Calendar.getInstance().apply { timeInMillis = time1 }
+    val cal2 = Calendar.getInstance().apply { timeInMillis = time2 }
+    return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) &&
+        cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR)
 }
 
 @Composable

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/ChatViewModel.kt
@@ -22,10 +22,12 @@ class ChatViewModel : ViewModel() {
 
     private var sentReg: ListenerRegistration? = null
     private var recvReg: ListenerRegistration? = null
+    private var groupReg: ListenerRegistration? = null
     private var sentList: List<Message> = emptyList()
     private var recvList: List<Message> = emptyList()
 
     fun listenPrivateMessages(currentUser: String, otherUser: String) {
+        groupReg?.remove(); groupReg = null
         sentReg?.remove(); recvReg?.remove()
         sentList = emptyList(); recvList = emptyList()
         _messages.value = emptyList()
@@ -38,7 +40,9 @@ class ChatViewModel : ViewModel() {
                     println("🔥 sent query error: ${e.message}")
                     return@addSnapshotListener
                 }
-                sentList = snap?.toObjects(Message::class.java).orEmpty()
+                sentList = snap?.toObjects(Message::class.java)
+                    ?.map(::normalizeMessage)
+                    .orEmpty()
                 publishMerged()
             }
 
@@ -50,8 +54,31 @@ class ChatViewModel : ViewModel() {
                     println("🔥 recv query error: ${e.message}")
                     return@addSnapshotListener
                 }
-                recvList = snap?.toObjects(Message::class.java).orEmpty()
+                recvList = snap?.toObjects(Message::class.java)
+                    ?.map(::normalizeMessage)
+                    .orEmpty()
                 publishMerged()
+            }
+    }
+
+    fun listenGroupMessages(groupId: String) {
+        sentReg?.remove(); recvReg?.remove()
+        sentReg = null; recvReg = null
+        sentList = emptyList(); recvList = emptyList()
+        _messages.value = emptyList()
+
+        groupReg?.remove()
+        groupReg = messagesCollection
+            .whereEqualTo("groupId", groupId)
+            .addSnapshotListener { snap, e ->
+                if (e != null) {
+                    println("🔥 group query error: ${e.message}")
+                    return@addSnapshotListener
+                }
+                val groupMessages = snap?.toObjects(Message::class.java)
+                    ?.map(::normalizeMessage)
+                    .orEmpty()
+                _messages.value = groupMessages.sortedBy { it.timestamp }
             }
     }
 
@@ -61,25 +88,88 @@ class ChatViewModel : ViewModel() {
             .sortedBy { it.timestamp }
     }
 
-    fun sendMessage(sender: String, receiver: String, text: String) {
+    fun sendDirectMessage(sender: String, receiver: String, text: String) {
+        if (text.isBlank()) return
         val docRef = messagesCollection.document()
         val newMessage = Message(
             id = docRef.id,
             sender = sender,
             receiver = receiver,
-            text = text,
+            groupId = null,
+            participants = listOf(sender, receiver).distinct(),
+            text = MessageCipher.encrypt(text),
             type = MessageType.TEXT,
             timestamp = System.currentTimeMillis()
         )
         docRef.set(newMessage)
     }
 
-    fun sendImageMessage(
+    fun sendGroupMessage(
+        sender: String,
+        groupId: String,
+        participants: List<String>,
+        text: String
+    ) {
+        if (text.isBlank()) return
+        val docRef = messagesCollection.document()
+        val message = Message(
+            id = docRef.id,
+            sender = sender,
+            receiver = "",
+            groupId = groupId,
+            participants = (participants + sender).distinct(),
+            text = MessageCipher.encrypt(text),
+            type = MessageType.TEXT,
+            timestamp = System.currentTimeMillis()
+        )
+        docRef.set(message)
+    }
+
+    fun sendDirectImageMessage(
         sender: String,
         receiver: String,
         imageUri: Uri,
         caption: String = "",
         onResult: (Boolean) -> Unit = {},
+    ) {
+        uploadAndSendImage(
+            sender = sender,
+            receiver = receiver,
+            groupId = null,
+            participants = listOf(sender, receiver).distinct(),
+            imageUri = imageUri,
+            caption = caption,
+            onResult = onResult
+        )
+    }
+
+    fun sendGroupImageMessage(
+        sender: String,
+        groupId: String,
+        participants: List<String>,
+        imageUri: Uri,
+        caption: String = "",
+        onResult: (Boolean) -> Unit = {},
+    ) {
+        uploadAndSendImage(
+            sender = sender,
+            receiver = "",
+            groupId = groupId,
+            participants = (participants + sender).distinct(),
+            imageUri = imageUri,
+            caption = caption,
+            onResult = onResult
+        )
+    }
+
+    private fun uploadAndSendImage(
+        sender: String,
+        receiver: String?,
+        groupId: String?,
+        participants: List<String>,
+        imageUri: Uri,
+        caption: String,
+        onResult: (Boolean) -> Unit
     ) {
         val fileName = "${UUID.randomUUID()}_${imageUri.lastPathSegment ?: "image"}"
         val imageRef = storageFolder.child(fileName)
@@ -96,8 +186,10 @@ class ChatViewModel : ViewModel() {
                 val imageMessage = Message(
                     id = docRef.id,
                     sender = sender,
-                    receiver = receiver,
-                    text = caption,
+                    receiver = receiver ?: "",
+                    groupId = groupId,
+                    participants = participants,
+                    text = MessageCipher.encrypt(caption),
                     imageUrl = downloadUri.toString(),
                     type = MessageType.IMAGE,
                     timestamp = System.currentTimeMillis()
@@ -115,8 +207,23 @@ class ChatViewModel : ViewModel() {
             }
     }
 
+    private fun normalizeMessage(message: Message): Message {
+        val participants = if (message.participants.isNotEmpty()) {
+            message.participants
+        } else {
+            listOfNotNull(
+                message.sender.takeIf { it.isNotBlank() },
+                message.receiver.takeIf { it.isNotBlank() }
+            )
+        }
+        return message.copy(
+            text = MessageCipher.decrypt(message.text),
+            participants = participants.distinct()
+        )
+    }
+
     override fun onCleared() {
-        sentReg?.remove(); recvReg?.remove()
+        sentReg?.remove(); recvReg?.remove(); groupReg?.remove()
         super.onCleared()
     }
 }

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/DrawerContent.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/DrawerContent.kt
@@ -1,61 +1,153 @@
 package com.example.lingaguchat.ui.chat
 
 import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.ListenerRegistration
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.*
 
 data class UserItem(
     val email: String,
-    val name: String
+    val name: String,
+    val isOnline: Boolean,
+    val lastSeen: Long?
+)
+
+data class GroupItem(
+    val id: String,
+    val name: String,
+    val members: List<String>
 )
 
 @Composable
 fun DrawerContent(
     currentUserEmail: String,
-    selectedUser: String?,
-    onAccountSelected: (String) -> Unit,
+    selectedChat: ChatDestination?,
+    onChatSelected: (ChatDestination) -> Unit,
     onSignOut: () -> Unit
 ) {
     val db = remember { FirebaseFirestore.getInstance() }
 
     var accounts by remember { mutableStateOf<List<UserItem>>(emptyList()) }
-    var loading by remember { mutableStateOf(true) }
+    var loadingUsers by remember { mutableStateOf(true) }
     var errorMsg by remember { mutableStateOf<String?>(null) }
 
-    // Registrar el listener una sola vez y limpiarlo al salir
-    DisposableEffect(Unit) {
-        var reg: ListenerRegistration? = null
-        reg = db.collection("users")
+    var groups by remember { mutableStateOf<List<GroupItem>>(emptyList()) }
+    var loadingGroups by remember { mutableStateOf(true) }
+    var groupsError by remember { mutableStateOf<String?>(null) }
+
+    DisposableEffect(currentUserEmail) {
+        val usersReg = db.collection("users")
             .addSnapshotListener { snapshot, e ->
-                loading = false
+                loadingUsers = false
                 if (e != null) {
                     errorMsg = e.message
-                    Log.e("DrawerContent", "Firestore error", e)
+                    Log.e("DrawerContent", "Firestore users error", e)
                     accounts = emptyList()
                     return@addSnapshotListener
                 }
                 val list = snapshot?.documents?.mapNotNull { doc ->
-                    val email = doc.getString("email")
-                    val name = doc.getString("name")
-                    if (email.isNullOrBlank() || name.isNullOrBlank()) null
-                    else UserItem(email, name)
+                    val email = doc.getString("email") ?: return@mapNotNull null
+                    val name = doc.getString("name") ?: email.substringBefore("@")
+                    val isOnline = doc.getBoolean("online") ?: false
+                    val lastSeen = doc.getLong("lastSeen")
+                    UserItem(email, name, isOnline, lastSeen)
                 }.orEmpty()
                 accounts = list
             }
-        onDispose { reg?.remove() }
+
+        val groupsReg = db.collection("groups")
+            .whereArrayContains("members", currentUserEmail)
+            .addSnapshotListener { snapshot, e ->
+                loadingGroups = false
+                if (e != null) {
+                    groupsError = e.message
+                    Log.e("DrawerContent", "Firestore groups error", e)
+                    groups = emptyList()
+                    return@addSnapshotListener
+                }
+                groups = snapshot?.documents?.mapNotNull { doc ->
+                    val id = doc.id
+                    val name = doc.getString("name") ?: "Grupo"
+                    val members = doc.get("members") as? List<String> ?: emptyList()
+                    GroupItem(id, name, members)
+                }.orEmpty()
+            }
+
+        onDispose {
+            usersReg?.remove()
+            groupsReg?.remove()
+        }
+    }
+
+    var showCreateGroup by remember { mutableStateOf(false) }
+    var createGroupError by remember { mutableStateOf<String?>(null) }
+    var creatingGroup by remember { mutableStateOf(false) }
+
+    if (showCreateGroup) {
+        CreateGroupDialog(
+            availableUsers = accounts.filter { it.email != currentUserEmail },
+            isProcessing = creatingGroup,
+            errorMessage = createGroupError,
+            onDismiss = {
+                if (!creatingGroup) {
+                    showCreateGroup = false
+                    createGroupError = null
+                }
+            },
+            onCreate = { name, selectedMembers ->
+                val trimmedName = name.trim()
+                if (trimmedName.isBlank()) {
+                    createGroupError = "Asigna un nombre al grupo"
+                    return@CreateGroupDialog
+                }
+                if (selectedMembers.isEmpty()) {
+                    createGroupError = "Selecciona al menos un integrante"
+                    return@CreateGroupDialog
+                }
+                creatingGroup = true
+                val payload = mapOf(
+                    "name" to trimmedName,
+                    "members" to (selectedMembers + currentUserEmail).distinct()
+                )
+                db.collection("groups")
+                    .add(payload)
+                    .addOnSuccessListener {
+                        creatingGroup = false
+                        createGroupError = null
+                        showCreateGroup = false
+                    }
+                    .addOnFailureListener {
+                        creatingGroup = false
+                        createGroupError = it.message
+                        Log.e("DrawerContent", "Create group error", it)
+                    }
+            }
+        )
     }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Selecciona un contacto", style = MaterialTheme.typography.titleMedium)
+        Text("Conversaciones", style = MaterialTheme.typography.titleMedium)
         Spacer(modifier = Modifier.height(12.dp))
 
+        Text("Contactos", style = MaterialTheme.typography.labelLarge)
+        Spacer(Modifier.height(4.dp))
+
         when {
-            loading -> {
+            loadingUsers -> {
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
                 Spacer(Modifier.height(12.dp))
                 Text("Cargando contactos…")
@@ -71,11 +163,38 @@ fun DrawerContent(
                 if (otherUsers.isEmpty()) {
                     Text("No hay contactos registrados todavía")
                 } else {
-                    otherUsers.forEach { user ->
-                        TextButton(onClick = { onAccountSelected(user.email) }) {
-                            Text(
-                                text = if (user.email == selectedUser)
-                                    "${user.name} (en chat)" else user.name
+                    LazyColumn(
+                        modifier = Modifier.heightIn(max = 220.dp)
+                    ) {
+                        items(otherUsers) { user ->
+                            val isSelected = selectedChat is ChatDestination.Private && selectedChat.email == user.email
+                            ListItem(
+                                headlineContent = {
+                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                        Text(user.name)
+                                        Spacer(Modifier.width(8.dp))
+                                        OnlineIndicator(isOnline = user.isOnline)
+                                    }
+                                },
+                                supportingContent = {
+                                    val statusText = if (user.isOnline) {
+                                        "En línea"
+                                    } else {
+                                        user.lastSeen?.let { formatLastSeen(it) } ?: "Desconectado"
+                                    }
+                                    Text(statusText)
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(MaterialTheme.shapes.small)
+                                    .background(
+                                        if (isSelected)
+                                            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+                                        else
+                                            MaterialTheme.colorScheme.surface
+                                    )
+                                    .padding(horizontal = 8.dp)
+                                    .clickable { onChatSelected(ChatDestination.Private(user.email)) }
                             )
                         }
                     }
@@ -83,7 +202,180 @@ fun DrawerContent(
             }
         }
 
-        Spacer(modifier = Modifier.height(24.dp))
-        Button(onClick = onSignOut) { Text("Cerrar sesión") }
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Grupos", style = MaterialTheme.typography.labelLarge)
+            Spacer(Modifier.weight(1f))
+            TextButton(onClick = { showCreateGroup = true }) {
+                Text("Nuevo grupo")
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+
+        when {
+            loadingGroups -> {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(8.dp))
+                Text("Cargando grupos…")
+            }
+            groupsError != null -> {
+                Text(
+                    "Error al cargar grupos: $groupsError",
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            groups.isEmpty() -> {
+                Text("Todavía no hay grupos")
+            }
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.heightIn(max = 200.dp)
+                ) {
+                    items(groups) { group ->
+                        val isSelected = selectedChat is ChatDestination.Group && selectedChat.id == group.id
+                        ListItem(
+                            headlineContent = { Text(group.name) },
+                            supportingContent = {
+                                Text("Integrantes: ${group.members.size}")
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(MaterialTheme.shapes.small)
+                                .background(
+                                    if (isSelected)
+                                        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+                                    else
+                                        MaterialTheme.colorScheme.surface
+                                )
+                                .padding(horizontal = 8.dp)
+                                .clickable {
+                                    onChatSelected(ChatDestination.Group(group.id, group.name, group.members))
+                                }
+                        )
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Divider()
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = onSignOut, modifier = Modifier.fillMaxWidth()) { Text("Cerrar sesión") }
     }
+}
+
+@Composable
+private fun CreateGroupDialog(
+    availableUsers: List<UserItem>,
+    isProcessing: Boolean,
+    errorMessage: String?,
+    onDismiss: () -> Unit,
+    onCreate: (String, List<String>) -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var selectedMembers by remember { mutableStateOf<Set<String>>(emptySet()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = { onCreate(name, selectedMembers.toList()) }, enabled = !isProcessing) {
+                if (isProcessing) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp))
+                } else {
+                    Text("Crear")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isProcessing) { Text("Cancelar") }
+        },
+        title = { Text("Crear grupo") },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Nombre del grupo") },
+                    enabled = !isProcessing,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(12.dp))
+                Text("Selecciona integrantes", style = MaterialTheme.typography.labelLarge)
+                Spacer(Modifier.height(8.dp))
+                if (availableUsers.isEmpty()) {
+                    Text("No hay otros usuarios disponibles aún")
+                } else {
+                    LazyColumn(modifier = Modifier.heightIn(max = 240.dp)) {
+                        items(availableUsers) { user ->
+                            val checked = selectedMembers.contains(user.email)
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .toggleable(
+                                        value = checked,
+                                        enabled = !isProcessing,
+                                        onValueChange = { value ->
+                                            selectedMembers = if (value) {
+                                                selectedMembers + user.email
+                                            } else {
+                                                selectedMembers - user.email
+                                            }
+                                        }
+                                    )
+                                    .padding(vertical = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Checkbox(
+                                    checked = checked,
+                                    onCheckedChange = null,
+                                    enabled = !isProcessing
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Column {
+                                    Text(user.name)
+                                    Text(user.email, style = MaterialTheme.typography.bodySmall)
+                                }
+                            }
+                        }
+                    }
+                }
+                errorMessage?.let {
+                    Spacer(Modifier.height(8.dp))
+                    Text(it, color = MaterialTheme.colorScheme.error)
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun OnlineIndicator(isOnline: Boolean) {
+    val color = if (isOnline) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.outlineVariant
+    Box(
+        modifier = Modifier
+            .size(10.dp)
+            .clip(CircleShape)
+            .background(color)
+    )
+}
+
+private fun formatLastSeen(lastSeen: Long): String {
+    val calendar = Calendar.getInstance().apply { timeInMillis = lastSeen }
+    val formatter: DateFormat = if (isSameDay(calendar.timeInMillis, System.currentTimeMillis())) {
+        DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault())
+    } else {
+        SimpleDateFormat("dd MMM yyyy HH:mm", Locale.getDefault())
+    }
+    return "Últ. vez ${formatter.format(Date(lastSeen))}"
+}
+
+private fun isSameDay(time1: Long, time2: Long): Boolean {
+    val cal1 = Calendar.getInstance().apply { timeInMillis = time1 }
+    val cal2 = Calendar.getInstance().apply { timeInMillis = time2 }
+    return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) &&
+        cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR)
 }

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/Message.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/Message.kt
@@ -6,6 +6,8 @@ data class Message(
     val id: String = "",
     val sender: String = "",
     val receiver: String = "",
+    val groupId: String? = null,
+    val participants: List<String> = emptyList(),
     val text: String = "",
     val imageUrl: String? = null,
     val type: MessageType = MessageType.TEXT,

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/MessageCipher.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/MessageCipher.kt
@@ -1,0 +1,37 @@
+package com.example.lingaguchat.ui.chat
+
+import android.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Simple AES helper to keep messages private at rest in Firestore.
+ * It is not meant to be bulletproof security but prevents texto plano.
+ */
+object MessageCipher {
+    private const val TRANSFORMATION = "AES/CBC/PKCS5Padding"
+    private val charset = Charsets.UTF_8
+    private val keySpec = SecretKeySpec("LinganguChatKey!".toByteArray(charset), "AES")
+    private val ivSpec = IvParameterSpec("LinganguChatIV!!".toByteArray(charset))
+
+    fun encrypt(plain: String): String {
+        if (plain.isBlank()) return plain
+        return runCatching {
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivSpec)
+            val encrypted = cipher.doFinal(plain.toByteArray(charset))
+            Base64.encodeToString(encrypted, Base64.NO_WRAP)
+        }.getOrElse { plain }
+    }
+
+    fun decrypt(encrypted: String): String {
+        if (encrypted.isBlank()) return encrypted
+        return runCatching {
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, ivSpec)
+            val decoded = Base64.decode(encrypted, Base64.NO_WRAP)
+            String(cipher.doFinal(decoded), charset)
+        }.getOrElse { encrypted }
+    }
+}

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/PresenceManager.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/PresenceManager.kt
@@ -1,0 +1,24 @@
+package com.example.lingaguchat.ui.chat
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+
+object PresenceManager {
+    private val usersCollection = FirebaseFirestore.getInstance().collection("users")
+
+    fun setOnline(email: String) {
+        val payload = mapOf(
+            "online" to true,
+            "lastSeen" to System.currentTimeMillis()
+        )
+        usersCollection.document(email).set(payload, SetOptions.merge())
+    }
+
+    fun setOffline(email: String) {
+        val payload = mapOf(
+            "online" to false,
+            "lastSeen" to System.currentTimeMillis()
+        )
+        usersCollection.document(email).set(payload, SetOptions.merge())
+    }
+}


### PR DESCRIPTION
## Summary
- add a chat destination model, encrypted message helper, and presence manager
- extend chat UI/view model to support group conversations, user status badges, and encrypted text/captions
- enhance navigation drawer with group management, online indicators, and message participant metadata

## Testing
- ./gradlew lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df2d3b31e083238563b40ae73ab13a