### PR TITLE
Use compose snapshotFlow import

### DIFF
--- a/app/src/main/java/com/example/lingaguchat/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/ChatScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -65,7 +66,6 @@ import java.util.UUID
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.snapshotFlow
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)


### PR DESCRIPTION
## Summary
- replace the chat screen snapshotFlow import with the compose runtime variant to avoid using the Flow extension

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b80f3c788323b42b7abdfc8d8216