### PR TITLE
Add chat document id field to Firestore payloads

### DIFF
--- a/app/src/main/java/com/example/lingaguchat/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/ChatViewModel.kt
@@ -138,6 +138,7 @@ class ChatViewModel : ViewModel() {
             messageRef.set(payload).await()
             chatRef.set(
                 mapOf(
+                    "id" to chatId,
                     "lastMessage" to trimmed,
                     "lastMessageSender" to sender,
                     "lastMessageType" to MessageType.TEXT.name.lowercase(),
@@ -177,6 +178,7 @@ class ChatViewModel : ViewModel() {
             val preview = if (captionText.isNotEmpty()) captionText else "📷 Imagen"
             chatRef.set(
                 mapOf(
+                    "id" to chatId,
                     "lastMessage" to preview,
                     "lastMessageSender" to sender,
                     "lastMessageType" to MessageType.IMAGE.name.lowercase(),

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/ChatsViewModel.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/ChatsViewModel.kt
@@ -97,6 +97,7 @@ class ChatsViewModel : ViewModel() {
             val snapshot = chatRef.get().await()
             if (!snapshot.exists()) {
                 val payload = mapOf(
+                    "id" to chatId,
                     "type" to ChatType.DIRECT.name.lowercase(Locale.ROOT),
                     "members" to orderedMembers,
                     "directKey" to key,
@@ -113,7 +114,13 @@ class ChatsViewModel : ViewModel() {
                 val existingLower = existingMemberStrings.map { it.lowercase(Locale.ROOT) }
                 val expectedLower = orderedMembers.map { it.lowercase(Locale.ROOT) }
                 if (existingLower != expectedLower || existingMemberStrings != orderedMembers) {
-                    chatRef.set(mapOf("members" to orderedMembers), SetOptions.merge()).await()
+                    chatRef.set(
+                        mapOf(
+                            "id" to chatId,
+                            "members" to orderedMembers
+                        ),
+                        SetOptions.merge()
+                    ).await()
                 }
             }
             chatRef.get().await().toChatSummary()
@@ -143,6 +150,7 @@ class ChatsViewModel : ViewModel() {
         return try {
             val chatRef = chatsCollection.document()
             val payload = mapOf(
+                "id" to chatRef.id,
                 "type" to ChatType.GROUP.name.lowercase(Locale.ROOT),
                 "name" to trimmedName,
                 "members" to distinctMembers,
@@ -194,8 +202,9 @@ class ChatsViewModel : ViewModel() {
             "text" -> MessageType.TEXT
             else -> null
         }
+        val chatId = getString("id")?.takeIf { it.isNotBlank() } ?: id
         return ChatSummary(
-            id = id,
+            id = chatId,
             type = chatType,
             name = getString("name"),
             members = members,


### PR DESCRIPTION
## Summary
- ensure chat documents persist their id field when created or updated
- read the stored id value when mapping Firestore chat summaries

## Testing
- ./gradlew lint *(fails: Android Gradle plugin 8.8.2 not available in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d00e0d508323b67b49110724459d