### PR TITLE
Add Firestore composite indexes for chat queries

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,28 @@
+{
+  "indexes": [
+    {
+      "collectionId": "chats",
+      "fields": [
+        { "fieldPath": "members", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "lastTimestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "timestamp", "order": "ASCENDING" },
+        { "fieldPath": "localTimestamp", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "timestamp", "order": "DESCENDING" },
+        { "fieldPath": "localTimestamp", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- add a firestore.indexes.json configuration to provision required composite indexes
- cover chat list and message queries so the app no longer errors about missing indexes

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2d1c5dd848323b88ecb54471b5ed1