### PR TITLE
Enable Firebase push notification token registration

### DIFF
--- a/app/src/main/java/com/example/lingaguchat/push/AppMessagingService.kt
+++ b/app/src/main/java/com/example/lingaguchat/push/AppMessagingService.kt
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationCompat
 import com.example.lingaguchat.MainActivity
 import com.example.lingaguchat.R
 import com.example.lingaguchat.ui.chat.MessageCipher
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.google.firebase.firestore.FirebaseFirestore
@@ -20,8 +21,9 @@ class AppMessagingService : FirebaseMessagingService() {
     private val CHANNEL_ID = "messages_channel_id"
 
     override fun onNewToken(token: String) {
-        // El AuthViewModel ya sube token, pero aquí puedes hacer un “best-effort”
-        // si quisieras (obtener email actual y subirlo).
+        super.onNewToken(token)
+        val email = FirebaseAuth.getInstance().currentUser?.email ?: return
+        FcmTokenManager.storeToken(email, token)
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {

--- a/app/src/main/java/com/example/lingaguchat/push/FcmTokenManager.kt
+++ b/app/src/main/java/com/example/lingaguchat/push/FcmTokenManager.kt
@@ -1,0 +1,42 @@
+package com.example.lingaguchat.push
+
+import android.util.Log
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+
+/**
+ * Se encarga de almacenar los tokens FCM en el documento del usuario.
+ */
+object FcmTokenManager {
+    private const val TAG = "FcmTokenManager"
+
+    fun storeToken(email: String, token: String) {
+        val cleanEmail = email.trim()
+        val cleanToken = token.trim()
+        if (cleanEmail.isEmpty() || cleanToken.isEmpty()) return
+
+        val docRef = FirebaseFirestore.getInstance()
+            .collection("users")
+            .document(cleanEmail)
+
+        docRef.update("fcmTokens", FieldValue.arrayUnion(cleanToken))
+            .addOnSuccessListener {
+                Log.d(TAG, "Token actualizado para $cleanEmail")
+            }
+            .addOnFailureListener { error ->
+                Log.w(TAG, "Fallo update() para $cleanEmail: ${error.message}")
+                val payload = mapOf(
+                    "fcmTokens" to FieldValue.arrayUnion(cleanToken),
+                    "updatedAt" to FieldValue.serverTimestamp()
+                )
+                docRef.set(payload, SetOptions.merge())
+                    .addOnSuccessListener {
+                        Log.d(TAG, "Token guardado via set() para $cleanEmail")
+                    }
+                    .addOnFailureListener { inner ->
+                        Log.e(TAG, "No se pudo guardar token para $cleanEmail", inner)
+                    }
+            }
+    }
+}

--- a/app/src/main/java/com/example/lingaguchat/ui/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/auth/AuthViewModel.kt
@@ -3,10 +3,12 @@ package com.example.lingaguchat.ui.auth
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import com.example.lingaguchat.push.FcmTokenManager
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
+import com.google.firebase.messaging.FirebaseMessaging
 
 data class AuthUiState(
     val isLoading: Boolean = false,
@@ -73,6 +75,7 @@ class AuthViewModel : ViewModel() {
                     } else {
                         println("✅ users/$email ya existe y está completo")
                     }
+                    ensureMessagingToken(email)
                 } else {
                     val finalName = (name ?: email.substringBefore("@")).trim()
                     val payload = mapOf(
@@ -84,6 +87,7 @@ class AuthViewModel : ViewModel() {
                     docRef.set(payload, SetOptions.merge())
                         .addOnSuccessListener {
                             println("✅ Creado users/$email con name='$finalName'")
+                            ensureMessagingToken(email)
                         }
                         .addOnFailureListener { e ->
                             println("❌ Error creando users/$email: ${e.message}")
@@ -102,10 +106,24 @@ class AuthViewModel : ViewModel() {
                 docRef.set(payload, SetOptions.merge())
                     .addOnSuccessListener {
                         println("✅ Creado (fallback) users/$email con name='$finalName'")
+                        ensureMessagingToken(email)
                     }
                     .addOnFailureListener { e2 ->
                         println("❌ Error (fallback) users/$email: ${e.message} / ${e2.message}")
                     }
+            }
+    }
+
+    private fun ensureMessagingToken(email: String) {
+        FirebaseMessaging.getInstance().token
+            .addOnCompleteListener { task ->
+                if (!task.isSuccessful) {
+                    println("⚠️ No se pudo obtener token FCM: ${task.exception?.message}")
+                    return@addOnCompleteListener
+                }
+                val token = task.result?.trim().orEmpty()
+                if (token.isBlank()) return@addOnCompleteListener
+                FcmTokenManager.storeToken(email, token)
             }
     }
 


### PR DESCRIPTION
## Summary
- add an FCM token manager that persists device tokens in each user document
- update the auth flow to fetch the current device token once the user document exists
- refresh the stored token from the Firebase messaging service when Firebase rotates it

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fa4f72b48323b89e2eff5488624a