### PR TITLE
Add chat creation push notifications

### DIFF
--- a/app/src/main/java/com/example/lingaguchat/push/AppMessagingService.kt
+++ b/app/src/main/java/com/example/lingaguchat/push/AppMessagingService.kt
@@ -28,10 +28,19 @@ class AppMessagingService : FirebaseMessagingService() {
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         val data = remoteMessage.data
+        val event = data["event"] ?: "message"
+        when (event) {
+            "chat_created" -> handleChatCreatedEvent(data)
+            else -> handleMessageEvent(data)
+        }
+    }
+
+    private fun handleMessageEvent(data: Map<String, String>) {
         val messageId = data["messageId"] ?: return
         val chatId = data["chatId"] ?: return
         val destType = data["destType"] ?: "private"
         val peer = data["peer"] ?: return
+        val groupName = data["groupName"]
 
         FirebaseFirestore.getInstance()
             .collection("chats")
@@ -46,7 +55,7 @@ class AppMessagingService : FirebaseMessagingService() {
                 val decrypted = MessageCipher.decrypt(encryptedText).trim()
 
                 val title = when (destType) {
-                    "group" -> data["groupName"] ?: "Nuevo mensaje"
+                    "group" -> groupName ?: "Nuevo mensaje"
                     else -> data["senderName"] ?: peer.substringBefore("@")
                 }
 
@@ -56,8 +65,34 @@ class AppMessagingService : FirebaseMessagingService() {
                     decrypted.ifBlank { "Nuevo mensaje" }
                 }
 
-                showNotification(title, preview, destType, peer, chatId, messageId)
+                showNotification(title, preview, destType, peer, chatId, messageId, groupName)
             }
+    }
+
+    private fun handleChatCreatedEvent(data: Map<String, String>) {
+        val chatId = data["chatId"] ?: return
+        val destType = data["destType"] ?: "private"
+        val peer = data["peer"] ?: chatId
+        val creator = data["creator"]
+        val creatorName = data["creatorName"].takeUnless { it.isNullOrBlank() }
+            ?: creator?.substringBefore("@")
+            ?: "Nuevo chat"
+        val groupName = data["groupName"].takeUnless { it.isNullOrBlank() }
+
+        val title = if (destType == "group") {
+            groupName ?: "Nuevo grupo"
+        } else {
+            creatorName
+        }
+
+        val body = if (destType == "group") {
+            val groupLabel = groupName ?: "nuevo grupo"
+            "$creatorName creó el grupo $groupLabel"
+        } else {
+            "$creatorName inició un chat contigo"
+        }
+
+        showNotification(title, body, destType, peer, chatId, null, groupName)
     }
 
     private fun showNotification(
@@ -66,7 +101,8 @@ class AppMessagingService : FirebaseMessagingService() {
         destType: String,
         peer: String,
         chatId: String,
-        messageId: String
+        messageId: String?,
+        groupName: String?
     ) {
         createChannelIfNeeded()
 
@@ -76,7 +112,8 @@ class AppMessagingService : FirebaseMessagingService() {
             putExtra("destType", destType) // "private" | "group"
             putExtra("peer", peer)         // email o groupId
             putExtra("chatId", chatId)
-            putExtra("messageId", messageId)
+            groupName?.let { putExtra("groupName", it) }
+            messageId?.let { putExtra("messageId", it) }
         }
 
         val pendingIntent = PendingIntent.getActivity(

--- a/app/src/main/java/com/example/lingaguchat/ui/chat/ChatsViewModel.kt
+++ b/app/src/main/java/com/example/lingaguchat/ui/chat/ChatsViewModel.kt
@@ -101,6 +101,7 @@ class ChatsViewModel : ViewModel() {
                     "type" to ChatType.DIRECT.name.lowercase(Locale.ROOT),
                     "members" to orderedMembers,
                     "directKey" to key,
+                    "createdBy" to normalizedCurrent,
                     "createdAt" to FieldValue.serverTimestamp(),
                     "lastTimestamp" to FieldValue.serverTimestamp()
                 )

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,6 +15,52 @@ const unique=<T>(arr:T[])=>{
   return Array.from(new Set(arr)).filter(Boolean) as T[];
 };
 
+type UserTokenDoc={
+  snap:admin.firestore.DocumentSnapshot;
+  tokens:string[];
+};
+
+const collectUserTokenDocs=async (
+  emails:string[],
+  usersCol:admin.firestore.CollectionReference
+):Promise<UserTokenDoc[]>=>{
+  const cleaned=unique(
+    emails
+      .map((email)=>typeof email==="string"?email.trim():"")
+      .filter((email):email is string=>Boolean(email))
+  );
+  if (cleaned.length===0) return [];
+
+  const snapshots=await Promise.all(
+    cleaned.map((email)=>usersCol.doc(email).get())
+  );
+
+  return snapshots.map((snap)=>{
+    const data=snap.data()||{};
+    const arr=Array.isArray(data.fcmTokens)?data.fcmTokens:[];
+    const tokens=arr
+      .filter((token):token is string=>typeof token==="string")
+      .map((token)=>token.trim())
+      .filter((token)=>token.length>0);
+    return {snap, tokens};
+  });
+};
+
+const removeInvalidTokens=async (
+  docs:UserTokenDoc[],
+  invalidTokens:string[]
+):Promise<void>=>{
+  if (invalidTokens.length===0) return;
+  await Promise.all(
+    docs.map(async ({snap, tokens})=>{
+      if (tokens.length===0) return;
+      const filtered=tokens.filter((token)=>!invalidTokens.includes(token));
+      if (filtered.length===tokens.length) return;
+      await snap.ref.update({fcmTokens: filtered});
+    })
+  );
+};
+
 /**
  * Envía notificaciones cuando se crea chats/{chatId}/messages/{messageId}.
  */
@@ -43,15 +89,8 @@ export const sendMessageNotification=onDocumentCreated(
     if (targets.length===0) return;
 
     const usersCol=db.collection("users");
-    const userDocs=await Promise.all(targets.map((email)=>usersCol.doc(email).get()));
-
-    const tokens:string[]=[];
-    for (const doc of userDocs) {
-      const data=doc.data()||{};
-      const arr:string[]=Array.isArray(data.fcmTokens)?data.fcmTokens:[];
-      for (const t of arr) if (t) tokens.push(t);
-    }
-    const uniqueTokens=unique(tokens);
+    const tokenDocs=await collectUserTokenDocs(targets, usersCol);
+    const uniqueTokens=unique(tokenDocs.flatMap((item)=>item.tokens));
     if (uniqueTokens.length===0) return;
 
     let senderName=sender.split("@")[0]||"Remitente";
@@ -64,6 +103,7 @@ export const sendMessageNotification=onDocumentCreated(
     }
 
     const data:{[k:string]:string}={
+      event: "message",
       messageId,
       chatId,
       destType: type==="group"?"group":"private",
@@ -104,17 +144,102 @@ export const sendMessageNotification=onDocumentCreated(
           }
         }
       });
+      await removeInvalidTokens(tokenDocs, toDelete);
+    } catch (e) {
+      console.error("sendMulticast error", e);
+    }
+  }
+);
 
-      if (toDelete.length>0) {
-        await Promise.all(
-          userDocs.map(async (docSnap)=>{
-            const d=docSnap.data()||{};
-            const arr:string[]=Array.isArray(d.fcmTokens)?d.fcmTokens:[];
-            const filtered=arr.filter((t)=>!toDelete.includes(t));
-            await docSnap.ref.update({fcmTokens: filtered});
-          })
-        );
+/**
+ * Envía notificaciones cuando se crea un chat en chats/{chatId}.
+ */
+export const sendChatCreatedNotification=onDocumentCreated(
+  "chats/{chatId}",
+  async (event)=>{
+    const chatId:string=event.params.chatId;
+    const snap=event.data;
+    if (!snap) return;
+
+    const chat=snap.data() as {
+      members?:unknown;
+      createdBy?:string;
+      type?:string;
+      name?:string;
+    };
+
+    const membersRaw=Array.isArray(chat.members)?chat.members:[];
+    const members=membersRaw
+      .map((member)=>typeof member==="string"?member.trim():"")
+      .filter((member):member is string=>member.length>0);
+    if (members.length===0) return;
+
+    const creator=(typeof chat.createdBy==="string"?chat.createdBy.trim():"");
+    const type=((typeof chat.type==="string"?chat.type:"direct").toLowerCase());
+    const targets=creator?members.filter((email)=>email!==creator):members;
+    if (targets.length===0) return;
+
+    const db=admin.firestore();
+    const usersCol=db.collection("users");
+    const tokenDocs=await collectUserTokenDocs(targets, usersCol);
+    const uniqueTokens=unique(tokenDocs.flatMap((item)=>item.tokens));
+    if (uniqueTokens.length===0) return;
+
+    let creatorName=creator.split("@")[0]||"Alguien";
+    if (creator) {
+      try {
+        const creatorSnap=await usersCol.doc(creator).get();
+        const name=creatorSnap.get("name") as string|undefined;
+        if (name) creatorName=name;
+      } catch {
+        // ignoramos errores al cargar el creador
       }
+    }
+
+    const data:{[k:string]:string}={
+      event: "chat_created",
+      chatId,
+      destType: type==="group"?"group":"private",
+      creator,
+      creatorName,
+    };
+
+    if (type==="group") {
+      const groupName=(
+        typeof chat.name==="string"?chat.name.trim():""
+      )||"Nuevo grupo";
+      data["groupName"]=groupName;
+      data["peer"]=chatId;
+    } else {
+      data["peer"]=creator||chatId;
+    }
+
+    const message:admin.messaging.MulticastMessage={
+      data,
+      tokens: uniqueTokens,
+      android: {priority: "high"},
+      apns: {headers: {"apns-priority": "10"}},
+    };
+
+    try {
+      const res=await admin.messaging().sendMulticast(message);
+      const toDelete:string[]=[];
+      res.responses.forEach((r, idx)=>{
+        if (!r.success) {
+          const err=r.error as {
+            code?:string;
+            errorInfo?:{code?:string};
+          }|undefined;
+          const code=(err&&(
+            (err.errorInfo&&err.errorInfo.code)||err.code
+          ))||"";
+          if (code==="messaging/registration-token-not-registered") {
+            toDelete.push(uniqueTokens[idx]);
+          }
+        }
+      });
+
+      await removeInvalidTokens(tokenDocs, toDelete);
     } catch (e) {
       console.error("sendMulticast error", e);
     }


### PR DESCRIPTION
## Summary
- add reusable helpers to collect FCM tokens and clean up invalid ones in the Cloud Functions
- extend message notifications with an event flag and add a chat-created notification trigger
- update the Android client to handle chat creation pushes and record the creator when making direct chats

## Testing
- npm run lint
- ./gradlew lint *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e40b630d588323948c1d016b58dea2